### PR TITLE
Add github under IDP section

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ _______________________________________________
 ## Internal Developers Platforms
 - [Humanitec](https://humanitec.com/)
 - [Mia Platform](https://mia-platform.eu/)
+- [GitHub as a Platform Engineering Platform](https://www.youtube.com/watch?v=B4ra4MWiZck)
 
 ## Templates
 - [Cookiecutter.io](https://cookiecutter.io)


### PR DESCRIPTION
Awesome repo!  Looking forward to seeing how it grows!

GitHub can be used as a Platform Engineering Platform if we give repositories distinct roles.

With GitHub, we can `Deploy [X] to [Y]` and abstract all the Infrastructure as code so that developers have a simple interface (namely, a GitHub Action), and the platform team can easily maintain proper GitOps practices.

The full video is here:
- [GitHub as a Platform Engineering Platform](https://www.youtube.com/watch?v=B4ra4MWiZck)