### PR TITLE
Add KubeStellar Console to Developers Portals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ _______________________________________________
 - [Atlassian Compass](https://www.atlassian.com/software/compass)
 - [CyCloid](https://www.cycloid.io/solutions/self-service-portal)
 - [Flanksource Mission Control](https://www.flanksource.com)
+- [KubeStellar Console](https://github.com/kubestellar/console) — Multi-cluster Kubernetes management console with AI-powered insights, MCP integration, and real-time observability across edge and cloud clusters.
 
 ## Internal Developers Platforms
 - [Humanitec](https://humanitec.com/)


### PR DESCRIPTION
Adds [KubeStellar Console](https://github.com/kubestellar/console) to the **Developers Portals** section.

KubeStellar Console is a multi-cluster Kubernetes management console that provides:

- **AI-powered insights** — Claude, OpenAI, and Gemini integrations for cluster analysis
- **MCP integration** — Model Context Protocol bridge for AI coding agents to manage Kubernetes
- **Real-time observability** — dashboards for pods, deployments, RBAC, Helm releases across clusters
- **Edge + cloud** — unified view of workloads across edge and cloud Kubernetes clusters
- **Self-service operations** — drill-down views for logs, events, and resource management

It fits alongside Backstage, Port, and Flanksource as an open-source developer portal focused on Kubernetes multi-cluster management.

**Repo:** https://github.com/kubestellar/console  
**License:** Apache-2.0