### PR TITLE
docs: add Bifrost to AI platform engineering tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@ _______________________________________________
 - [LiteLLM](https://litellm.ai/) — Call all LLM APIs using the OpenAI format (AI Gateway).
 - [Langfuse](https://langfuse.com/) — Open source LLM engineering platform (Observability, Analytics, Prompt Management).
 - [Portkey](https://portkey.ai/) — Enterprise AI gateway and observability platform for production LLM apps.
+- [Bifrost](https://github.com/maximhq/bifrost) — High-performance, OpenAI-compatible AI gateway with multi-provider routing, fallbacks, load balancing, virtual keys, and observability.


### PR DESCRIPTION
## Summary
- add Bifrost to AI Platform Engineering & LLMOps

## Why
Bifrost is a self-hostable, OpenAI-compatible AI gateway with multi-provider routing, fallbacks, load balancing, virtual keys, and observability.

Bifrost: https://github.com/maximhq/bifrost